### PR TITLE
CSCTTV-4183 researchfiUrl modification

### DIFF
--- a/aspnetcore/src/Repositories/PublicationIndexRepository.cs
+++ b/aspnetcore/src/Repositories/PublicationIndexRepository.cs
@@ -349,6 +349,10 @@ public class PublicationIndexRepository : IndexRepositoryBase<Publication>
 
     private static void HandleResearchfiUrl(Publication publication)
     {
-        publication.ResearchfiUrl = new ResearchfiUrl(resourceType: "publication", id: publication.Id);
+        // Organization part of a copublication (osajulkaisu) does not have a ResearchfiUrl
+        if (!publication.IsOrgPublication)
+        {
+            publication.ResearchfiUrl = new ResearchfiUrl(resourceType: "publication", id: publication.Id);
+        }
     }
 }


### PR DESCRIPTION
Modify researchfiUrl handling for publications. Organization part of a co-publication does not have a researchfiUrl.