### PR TITLE
CSCTTV-4287-add-custom-sort-field-for-export

### DIFF
--- a/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/QueryGeneratorBase.cs
+++ b/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/QueryGeneratorBase.cs
@@ -30,14 +30,14 @@ public abstract class QueryGeneratorBase<TIn, TOut> : IQueryGenerator<TIn, TOut>
             return descriptor => descriptor
                 .Index(indexName)
                 .Take(pageSize)
-                .Sort(sort => sort.Ascending(SortSpecialField.DocumentIndexOrder))
+                .Sort(sort => sort.Ascending("ExportSortId"))
                 .Query(GenerateQueryForSearch(searchParameters));
         }
         else {
             return descriptor => descriptor
                 .Index(indexName)
                 .Take(pageSize)
-                .Sort(sort => sort.Ascending(SortSpecialField.DocumentIndexOrder))
+                .Sort(sort => sort.Ascending("ExportSortId"))
                 .Query(GenerateQueryForSearch(searchParameters))
                 .SearchAfter(searchAfter);
         }

--- a/aspnetcore/src/Repositories/Maps/FundingCallProfile.cs
+++ b/aspnetcore/src/Repositories/Maps/FundingCallProfile.cs
@@ -14,6 +14,7 @@ public class FundingCallProfile : Profile
         AllowNullDestinationValues = true;
         
         CreateProjection<DimCallProgramme, FundingCall>()
+            .ForMember(dst => dst.ExportSortId, opt => opt.MapFrom(src => (long)src.Id))
             .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dst => dst.NameFi, opt => opt.MapFrom(src => src.NameFi))
             .ForMember(dst => dst.NameSv, opt => opt.MapFrom(src => src.NameSv))

--- a/aspnetcore/src/Repositories/Maps/FundingDecisionProfile.cs
+++ b/aspnetcore/src/Repositories/Maps/FundingDecisionProfile.cs
@@ -16,6 +16,7 @@ public class FundingDecisionProfile : Profile
         AllowNullDestinationValues = true;
         
         CreateProjection<DimFundingDecision, FundingDecision>()
+            .ForMember(dst => dst.ExportSortId, opt => opt.MapFrom(src => (long)src.Id))
             .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dst => dst.NameFi, opt => opt.MapFrom(src => src.NameFi))
             .ForMember(dst => dst.NameSv, opt => opt.MapFrom(src => src.NameSv))

--- a/aspnetcore/src/Repositories/Maps/PublicationProfile.cs
+++ b/aspnetcore/src/Repositories/Maps/PublicationProfile.cs
@@ -20,6 +20,7 @@ public class PublicationProfile : Profile
         
         CreateProjection<DimPublication, Publication>()
             .AddTransform<string?>(s => string.IsNullOrWhiteSpace(s) ? null : s)
+            .ForMember(dst => dst.ExportSortId, opt => opt.MapFrom(src => (long)src.Id))
             .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.PublicationId))
             .ForMember(dst => dst.OriginalPublicationId, opt => opt.MapFrom(src => src.OriginalPublicationId))
             .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.PublicationName))

--- a/aspnetcore/src/Repositories/Maps/ResearchDatasetProfile.cs
+++ b/aspnetcore/src/Repositories/Maps/ResearchDatasetProfile.cs
@@ -16,6 +16,7 @@ public class ResearchDatasetProfile : Profile
         AllowNullDestinationValues = true;
         
         CreateProjection<DimResearchDataset, ResearchDataset>()
+            .ForMember(dst => dst.ExportSortId, opt => opt.MapFrom(src => (long)src.Id))
             .ForMember(dst => dst.DatabaseId, opt => opt.MapFrom(src => src.Id))
             .ForMember(dst => dst.NameFi, opt => opt.MapFrom(src => src.NameFi))
             .ForMember(dst => dst.NameSv, opt => opt.MapFrom(src => src.NameSv))

--- a/aspnetcore/src/Service.Models/FundingCall/FundingCall.cs
+++ b/aspnetcore/src/Service.Models/FundingCall/FundingCall.cs
@@ -4,6 +4,8 @@ namespace CSC.PublicApi.Service.Models.FundingCall;
 
 public class FundingCall
 {
+    public long ExportSortId { get; set; }
+
     /// <summary>
     /// Haun nimi
     /// </summary>

--- a/aspnetcore/src/Service.Models/FundingDecision/FundingDecision.cs
+++ b/aspnetcore/src/Service.Models/FundingDecision/FundingDecision.cs
@@ -4,6 +4,7 @@ namespace CSC.PublicApi.Service.Models.FundingDecision;
 
 public class FundingDecision
 {
+    public long ExportSortId { get; set; }
     public string? NameFi { get; set; }
 
     public string? NameSv { get; set; }

--- a/aspnetcore/src/Service.Models/Publication/Publication.cs
+++ b/aspnetcore/src/Service.Models/Publication/Publication.cs
@@ -7,6 +7,8 @@ namespace CSC.PublicApi.Service.Models.Publication;
 /// </summary>
 public class Publication
 {
+    public long ExportSortId { get; set; }
+
     /// <summary>
     /// Julkaisun tunnus
     /// </summary>

--- a/aspnetcore/src/Service.Models/ResearchDataset/ResearchDataset.cs
+++ b/aspnetcore/src/Service.Models/ResearchDataset/ResearchDataset.cs
@@ -4,6 +4,7 @@ namespace CSC.PublicApi.Service.Models.ResearchDataset;
 
 public class ResearchDataset
 {
+    public long ExportSortId { get; set; }
     [Keyword]
     public string? Id { get; set; }
 

--- a/aspnetcore/test/Indexer.Tests/Maps/FundingCallProfileTest.cs
+++ b/aspnetcore/test/Indexer.Tests/Maps/FundingCallProfileTest.cs
@@ -53,6 +53,7 @@ public class FundingCallProfileTest
     {
         return new DimCallProgramme
         {
+            Id = 123456789,
             NameFi = "nameFi",
             NameSv = "nameSv",
             NameEn = "nameEn",
@@ -134,6 +135,8 @@ public class FundingCallProfileTest
     {
         return new FundingCall
         {
+            ExportSortId = 123456789,
+            Id = 123456789,
             NameFi = "nameFi",
             NameSv = "nameSv",
             NameEn = "nameEn",

--- a/aspnetcore/test/Indexer.Tests/Maps/FundingDecisionProfileTest.cs
+++ b/aspnetcore/test/Indexer.Tests/Maps/FundingDecisionProfileTest.cs
@@ -106,6 +106,7 @@ public class FundingDecisionProfileTest
     {
         return new DimFundingDecision
         {
+            Id = 123456789,
             NameFi = "namefi",
             NameSv = "namesv",
             NameEn = "nameen",
@@ -291,6 +292,8 @@ public class FundingDecisionProfileTest
     {
         return new FundingDecision
         {
+            ExportSortId = 123456789,
+            Id = 123456789,
             NameFi = "namefi",
             NameSv = "namesv",
             NameEn = "nameen",

--- a/aspnetcore/test/Indexer.Tests/Maps/PublicationProfileTest.cs
+++ b/aspnetcore/test/Indexer.Tests/Maps/PublicationProfileTest.cs
@@ -197,7 +197,7 @@ public class PublicationProfileTest
     {
         DimPublication dimPublication = new()
         {
-            Id = 1,
+            Id = 123456789,
             PublicationId = "publicationId",
             OriginalPublicationId = "abc123",
             PublicationName = "nameFi",
@@ -475,6 +475,7 @@ public class PublicationProfileTest
     {
         return new Publication
         {
+            ExportSortId = 123456789,
             Id = "publicationId",
             OriginalPublicationId = "abc123",
             Name = "nameFi",

--- a/aspnetcore/test/Indexer.Tests/Maps/ResearchDatasetProfileTest.cs
+++ b/aspnetcore/test/Indexer.Tests/Maps/ResearchDatasetProfileTest.cs
@@ -277,6 +277,7 @@ public class ResearchDatasetProfileTest
     {
         return new ResearchDataset
         {
+            ExportSortId = 32410,
             DatabaseId = Id,
             NameFi = "nameFi",
             NameSv = "nameSv",


### PR DESCRIPTION
Add custom field ExportSortId to Elasticsearch indexes. Use the new field in export endpoint sort criteria.