### PR TITLE
CSCTTV-3798 Total count in export endpoints

### DIFF
--- a/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/IQueryGenerator.cs
+++ b/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/IQueryGenerator.cs
@@ -7,4 +7,5 @@ public interface IQueryGenerator<TIn, TOut> where TOut : class
     Func<SearchDescriptor<TOut>, ISearchRequest> GenerateQuery(TIn searchParameters, int pageNumber, int pageSize);
     Func<SearchDescriptor<TOut>, ISearchRequest> GenerateQuerySearchAfter(TIn searchParameters, int pageSize, long? searchAfter);
     Func<SearchDescriptor<TOut>, ISearchRequest> GenerateSingleQuery(string id);
+    Func<CountDescriptor<TOut>, ICountRequest> GenerateCountQuery(TIn searchParameters);
 }

--- a/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/QueryGeneratorBase.cs
+++ b/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/QueryGeneratorBase.cs
@@ -51,6 +51,14 @@ public abstract class QueryGeneratorBase<TIn, TOut> : IQueryGenerator<TIn, TOut>
             .Query(GenerateQueryForSingle(id));
     }
 
+    public Func<CountDescriptor<TOut>, ICountRequest> GenerateCountQuery(TIn searchParameters)
+    {
+        var indexName = _configuration.GetIndexNameForType(typeof(TOut));
+        return descriptor => descriptor
+            .Index(indexName)
+            .Query(GenerateQueryForSearch(searchParameters));
+    }
+
     protected abstract Func<QueryContainerDescriptor<TOut>, QueryContainer> GenerateQueryForSearch(TIn parameters);
 
     protected abstract Func<QueryContainerDescriptor<TOut>,QueryContainer> GenerateQueryForSingle(string id);

--- a/aspnetcore/src/ElasticService/SearchAfterResult.cs
+++ b/aspnetcore/src/ElasticService/SearchAfterResult.cs
@@ -4,9 +4,12 @@ public class SearchAfterResult
 {
     public long? SearchAfter { get; }
     public int PageSize { get; }
-    public SearchAfterResult(long? searchAfter, int pageSize)
+
+    public long? TotalResults { get; set; }
+    public SearchAfterResult(long? searchAfter, int pageSize, long? totalResults = null)
     {
         SearchAfter = searchAfter;
         PageSize = pageSize;
+        TotalResults = totalResults;
     }
 }

--- a/aspnetcore/src/Interface/Controllers/ResponseHelper.cs
+++ b/aspnetcore/src/Interface/Controllers/ResponseHelper.cs
@@ -30,6 +30,7 @@ public static class ResponseHelper
         httpContext.Response.Headers.Add("x-page-size", searchAfterResult.PageSize.ToString());
         if (searchAfterResult.SearchAfter != null)
         {
+            httpContext.Response.Headers.Add("x-total", searchAfterResult.TotalResults.ToString());
             httpContext.Response.Headers.Add("x-next-page-token", searchAfterResult.SearchAfter.ToString());
             httpContext.Response.Headers.Add("link", GetLinksSearchAfter(httpContext.Request, searchAfterResult.SearchAfter));
         }


### PR DESCRIPTION
With export endpoints use additional Count query to get total number of matches. Return the count response headers.