### PR TITLE
Add ExportSortId as a sort criteria to all endpoints using Elasticsearch data source

### DIFF
--- a/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/FundingCallQueryGenerator.cs
+++ b/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/FundingCallQueryGenerator.cs
@@ -136,6 +136,7 @@ public class FundingCallQueryGenerator : QueryGeneratorBase<FundingCallSearchPar
     {
         // Sort funding calls
         return sortDescriptor => sortDescriptor
-            .Field(f => f.CallProgrammeDueDate, SortOrder.Ascending);
+            .Field(f => f.CallProgrammeDueDate, SortOrder.Ascending)
+            .Field(f => f.ExportSortId, SortOrder.Ascending); // DO NOT REMOVE, prevents duplicates in the result set
     }
 }

--- a/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/FundingDecisionQueryGenerator.cs
+++ b/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/FundingDecisionQueryGenerator.cs
@@ -179,6 +179,7 @@ public class FundingDecisionQueryGenerator : QueryGeneratorBase<FundingDecisionS
     {
         // Sort funding decisions
         return sortDescriptor => sortDescriptor
-            .Field(f => f.FundingStartDate, SortOrder.Descending);
+            .Field(f => f.FundingStartDate, SortOrder.Descending)
+            .Field(f => f.ExportSortId, SortOrder.Ascending); // DO NOT REMOVE, prevents duplicates in the result set
     }
 }

--- a/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/PublicationQueryGenerator.cs
+++ b/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/PublicationQueryGenerator.cs
@@ -343,6 +343,7 @@ public class PublicationQueryGenerator : QueryGeneratorBase<PublicationSearchPar
     {
         // Sort publications
         return sortDescriptor => sortDescriptor
-            .Field(f => f.PublicationYear, SortOrder.Descending);
+            .Field(f => f.PublicationYear, SortOrder.Descending)
+            .Field(f => f.ExportSortId, SortOrder.Ascending); // DO NOT REMOVE, prevents duplicates in the result set
     }
 }

--- a/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/ResearchDatasetQueryGenerator.cs
+++ b/aspnetcore/src/ElasticService/ElasticSearchQueryGenerators/ResearchDatasetQueryGenerator.cs
@@ -216,6 +216,7 @@ public class ResearchDatasetQueryGenerator : QueryGeneratorBase<ResearchDatasetS
     {
         // Sort research datasets
         return sortDescriptor => sortDescriptor
-            .Field(f => f.Created, SortOrder.Descending);
+            .Field(f => f.Created, SortOrder.Descending)
+            .Field(f => f.ExportSortId, SortOrder.Ascending); // DO NOT REMOVE, prevents duplicates in the result set
     }
 }


### PR DESCRIPTION
Add ExportSortId as a sort criteria in all endpoints, which query data from Elasticsearch. This prevents duplicates in search results.